### PR TITLE
Implements Alpha.Parameters and Insight.ScoreFinal

### DIFF
--- a/AlphaStream/Models/Alpha.py
+++ b/AlphaStream/Models/Alpha.py
@@ -54,6 +54,8 @@ class Alpha(object):
 
         self.Tags = json.get('tags', [])
 
+        self.Parameters = json.get('parameters', None)
+
     def __repr__(self):
         return f'''
 Alpha Id: {self.Id}

--- a/AlphaStream/Models/Insight.py
+++ b/AlphaStream/Models/Insight.py
@@ -34,8 +34,10 @@ class Insight:
         self.Symbol = json.get('symbol', None)
 
         self.Ticker = json.get('ticker', None)
-        
+
         self.Invalid = json.get('invalid', None)
+
+        self.ScoreFinal = json.get('score-final', False)
 
     def __repr__(self):
         return f'{self.CreatedTime} Alpha {self.Source} {self.Type} insight for {self.Ticker:<10} going {self.Direction} over the next {self.Period}s'

--- a/AlphaStream/Requests/SearchAlphasRequest.py
+++ b/AlphaStream/Requests/SearchAlphasRequest.py
@@ -6,37 +6,41 @@ class SearchAlphasRequest(object):
 
         kwargs = kwargs.get('kwargs', kwargs)
 
-        self.Accuracy = kwargs.get('accuracy', None)
+        self.Start = kwargs.get('start', 0)
+
+        self.Symbols = kwargs.get('symbols', [])
 
         self.AssetClasses = kwargs.get('assetClasses', [])
 
         self.Author = kwargs.get('author', None)
 
-        self.ExclusiveFeeMinimum = kwargs.get('exclusiveFeeMinimum', None)
-
-        self.ExclusiveFeeMaximum = kwargs.get('exclusiveFeeMaximum', None)
-
         self.ProjectId = kwargs.get('projectId', None)
-
-        self.SharedFeeMinimum = kwargs.get('sharedFeeMinimum', None)
-
-        self.SharedFeeMaximum = kwargs.get('sharedFeeMaximum', None)
-
-        self.SharpeMinimum = kwargs.get('sharpeMinimum', None)
-
-        self.SharpeMaximum = kwargs.get('sharpeMaximum', None)
-
-        self.Start = kwargs.get('start', 0)
-
-        self.Symbols = kwargs.get('symbols', [])
-
-        self.UniquenessMinimum = kwargs.get('uniquenessMinimum', None)
-
-        self.UniquenessMaximum = kwargs.get('uniquenessMaximum', None)
 
         self.IncludedTags = kwargs.get('includedTags', [])
 
         self.ExcludedTags = kwargs.get('excludedTags', [])
+
+        self.AccuracyMinimum, self.AccuracyMaximum = self._get_range(kwargs, 'accuracy')
+
+        self.ExclusiveFeeMinimum, self.ExclusiveFeeMaximum = self._get_range(kwargs, 'exclusive')
+
+        self.SharedFeeMinimum, self.SharedFeeMaximum = self._get_range(kwargs, 'shared')
+
+        self.ParametersMinimum, self.ParametersMaximum = self._get_range(kwargs, 'parameters')
+
+        self.SharpeMinimum, self.SharpeMaximum = self._get_range(kwargs, 'sharpe')
+
+        self.UniquenessMinimum, self.UniquenessMaximum = self._get_range(kwargs, 'uniqueness')
+
+
+    def _get_range(self, kwargs, key):
+
+        # If we have the key, it is a list with the minimum and maximum values
+        value = kwargs.get(key, [])
+        if isinstance(value, list) and len(value) > 0:
+            return min(value), max(value)
+
+        return kwargs.get(f'{key}-minimum', None), kwargs.get(f'{key}-maximum', None)
 
 
     def GetPayload(self):
@@ -48,8 +52,11 @@ class SearchAlphasRequest(object):
         }
 
         # Optional properties
-        if self.Accuracy is not None:
-            payload['accuracy'] = self.Accuracy
+        if self.AccuracyMinimum is not None:
+            payload['accuracy-minimum'] = self.AccuracyMinimum
+
+        if self.AccuracyMaximum is not None:
+            payload['accuracy-maximum'] = self.AccuracyMaximum
 
         if len(self.AssetClasses) > 0:
             payload['asset-classes'] = self.AssetClasses
@@ -92,5 +99,11 @@ class SearchAlphasRequest(object):
 
         if self.ExcludedTags is not None:
             payload['exclude'] = self.ExcludedTags
+
+        if self.ParametersMinimum is not None:
+            payload['parameters-minimum'] = self.ParametersMinimum
+
+        if self.ParametersMaximum is not None:
+            payload['parameters-maximum'] = self.ParametersMaximum
 
         return payload

--- a/AlphaStream/Requests/SearchAuthorsRequest.py
+++ b/AlphaStream/Requests/SearchAuthorsRequest.py
@@ -1,98 +1,92 @@
-from datetime import datetime
-
 class SearchAuthorsRequest(object): 
 
     def __init__(self, *args, **kwargs):
         self.Endpoint = "alpha/author/search"
-        
+
         kwargs = kwargs.get('kwargs', kwargs)
-        
-        self.Location = kwargs.get('location', None)
-        
-        self.Languages = kwargs.get('languages', [])
-        
-        self.Biography = kwargs.get('biography', None)
-        
-        self.AlphasListedMinimum = kwargs.get('alphasListedMinimum', None)
-        
-        self.AlphasListedMaximum = kwargs.get('alphasListedMaximum', None)
-        
-        self.SignedUpMinimum = kwargs.get('signedUpMinimum', None)
-        
-        self.SignedUpMaximum = kwargs.get('signedUpMaximum', None)
-        
-        self.LastLoginMinimum = kwargs.get('lastLoginMinimum', None)
-        
-        self.LastLoginMaximum = kwargs.get('lastLoginMaximum', None)
-        
-        self.ForumDiscussionsMinimum = kwargs.get('forumDiscussionsMinimum', None)
-        
-        self.ForumDiscussionsMaximum = kwargs.get('forumDiscussionsMaximum', None)
-        
-        self.ForumCommentsMinimum = kwargs.get('forumCommentsMinimum', None)
-        
-        self.ForumCommentsMaximum = kwargs.get('forumCommentsMaximum', None)
-        
-        self.ProjectsMinimum = kwargs.get('projectsMinimum', None)
-        
-        self.ProjectsMaximum = kwargs.get('projectsMaximum', None)
-        
+
         self.Start = kwargs.get('start', None)
-        
-        
+
+        self.Location = kwargs.get('location', None)
+
+        self.Languages = kwargs.get('languages', [])
+
+        self.Biography = kwargs.get('biography', None)
+
+        self.AlphasListedMinimum, self.AlphasListedMaximum = self._get_range(kwargs, 'alphasListed')
+
+        self.SignedUpMinimum, self.SignedUpMaximum = self._get_range(kwargs, 'signedUp')
+
+        self.LastLoginMinimum, self.LastLoginMaximum = self._get_range(kwargs, 'lastLogin')
+
+        self.ForumDiscussionsMinimum, self.ForumDiscussionsMaximum = self._get_range(kwargs, 'forumDiscussions')
+
+        self.ForumCommentsMinimum, self.ForumCommentsMaximum = self._get_range(kwargs, 'forumComments')
+
+        self.ProjectsMinimum, self.ProjectsMaximum = self._get_range(kwargs, 'projects')
+
+
+    def _get_range(self, kwargs, key):
+
+        # If we have the key, it is a list with the minimum and maximum values
+        value = kwargs.get(key, [])
+        if isinstance(value, list) and len(value) > 0:
+            return min(value), max(value)
+
+        return kwargs.get(f'{key}Minimum', None), kwargs.get(f'{key}Maximum', None)
+
     def GetPayload(self):
-    
         """ Construct author search query data payload from the initialized properties """
-        
+
         # Common default properties
         payload = {
             "start": self.Start 
         }
-          
+
         # Optional properties
         if self.Location is not None:
             payload['location'] = self.Location
-        
+
         if len(self.Languages) > 0:
             payload['languages'] = self.Languages
-        
+
         if self.Biography is not None:
             payload['biography'] = self.Biography
-        
+
         if self.AlphasListedMinimum is not None:
             payload['alphas-listed-minimum'] = self.AlphasListedMinimum
-            
+
         if self.AlphasListedMaximum is not None:
             payload['alphas-listed-maximum'] = self.AlphasListedMaximum
-        
+
         if self.SignedUpMinimum is not None:
             payload['signed-up-minimum'] = self.SignedUpMinimum
-            
+
         if self.SignedUpMaximum is not None:
             payload['signed-up-maximum'] = self.SignedUpMaximum
-            
+
         if self.LastLoginMinimum is not None:
             payload['last-login-minimum'] = self.LastLoginMinimum
-            
+
         if self.LastLoginMaximum is not None:
             payload['last-login-maximum'] = self.LastLoginMaximum
-            
+
         if self.ForumDiscussionsMinimum is not None:
             payload['forum-discussions-minimum'] = self.ForumDiscussionsMinimum
-            
+
         if self.ForumDiscussionsMaximum is not None:
             payload['forum-discussions-maximum'] = self.ForumDiscussionsMaximum
-        
+
         if self.ForumCommentsMinimum is not None:
             payload['forum-comments-minimum'] = self.ForumCommentsMinimum
-            
+
         if self.ForumCommentsMaximum is not None:
             payload['forum-comments-maximum'] = self.ForumCommentsMaximum
-            
+
         if self.ProjectsMinimum is not None:
             payload['projects-minimum'] = self.ProjectsMinimum
-            
+
         if self.ProjectsMaximum is not None:
             payload['projects-maximum'] = self.ProjectsMaximum
-        
+
         return payload

--- a/QuantConnect.AlphaStream/Models/Alpha.cs
+++ b/QuantConnect.AlphaStream/Models/Alpha.cs
@@ -123,5 +123,12 @@ namespace QuantConnect.AlphaStream.Models
         /// </summary>
         [JsonProperty("tags")]
         public List<string> Tags { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Represents the number of parameters that the alpha uses.
+        /// If the alpha has not been reviewed for parameters this value is null.
+        /// </summary>
+        [JsonProperty("parameters")]
+        public int? Parameters { get; set; } = null;
     }
 }

--- a/QuantConnect.AlphaStream/Models/Insight.cs
+++ b/QuantConnect.AlphaStream/Models/Insight.cs
@@ -98,5 +98,11 @@ namespace QuantConnect.AlphaStream.Models
         /// </summary>
         [JsonProperty("ticker")]
         public string Ticker { get; set; }
+
+        /// <summary>
+        /// Indicates whether the insight scores are final
+        /// </summary>
+        [JsonProperty("score-final")]
+        public bool ScoreFinal { get; set; } = false;
     }
 }

--- a/QuantConnect.AlphaStream/Requests/SearchAlphasRequest.cs
+++ b/QuantConnect.AlphaStream/Requests/SearchAlphasRequest.cs
@@ -82,5 +82,11 @@ namespace QuantConnect.AlphaStream.Requests
         /// </summary>
         [QueryParameter("exclude")]
         public List<string> ExcludedTags { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Search for Alphas with parameters in a specific range
+        /// </summary>
+        [QueryParameter("parameters")]
+        public NumberRange<int> Parameters { get; set; } = null;
     }
 }


### PR DESCRIPTION
Implement new attributes to the `Alpha` and `Insight` classes: `Parameters` and `ScoreFinal` respectively.
Adds `Parameters` to `SeachAlphaRequest`.

Refactors Python version of `SearchAlphaRequest` and `SearchAuthorRequest` in order to make range search easy. Without breaking current API, users can do range searches using a list. For example:
```python
client.SearchAuthors( projects = [5, 10])
```
which is equivalent to
```python
client.SearchAuthors( projectsMinimum = 5, projectsMinimum = 10 )
```