### PR TITLE
Adds TTL Setting in RMQ Queue Declaration

### DIFF
--- a/AlphaStream/AlphaInsightsStreamClient.py
+++ b/AlphaStream/AlphaInsightsStreamClient.py
@@ -19,11 +19,12 @@ class AlphaInsightsStreamClient(object):
         # Declare queue and bind to exchange:
         self.__connection = pika.BlockingConnection( parameters )
         self.__channel = self.__connection.channel()
-
+        
 
     def StreamSynchronously(self, alphaId, timeout=10):
         """ Stream a specific alpha id to a supplied callback method for timeout seconds. """
-        result = self.__channel.queue_declare(queue=alphaId, durable=False, exclusive=False, auto_delete=True)
+        result = self.__channel.queue_declare(queue=alphaId, durable=False, exclusive=False, auto_delete=True,
+                                              arguments={'x-message-ttl': 60000})
         queue = self.__channel.queue_bind(exchange=self.__exchange, queue=alphaId, routing_key=alphaId)
         end = time() + timeout
 

--- a/QuantConnect.AlphaStream/AlphaInsightsStreamClient.cs
+++ b/QuantConnect.AlphaStream/AlphaInsightsStreamClient.cs
@@ -91,7 +91,8 @@ namespace QuantConnect.AlphaStream
             consumer.Unregistered += ConsumerOnUnregistered;
 
             // declare and bind to queue (queue declaration is idempotent)
-            channel.QueueDeclare(request.AlphaId, false, false);
+            channel.QueueDeclare(request.AlphaId, false, false,
+                arguments: new Dictionary<string, object> {{"x-message-ttl", 60000}});
             channel.QueueBind(request.AlphaId, credentials.ExchangeName, request.AlphaId);
             channel.BasicConsume(consumer, request.AlphaId, true);
 


### PR DESCRIPTION
The message queue needs a TTL (time to live) definition to set the maximum time that the queue will hold a message.
https://www.rabbitmq.com/ttl.html