### PR TITLE
Adds alpha out of sample insights

### DIFF
--- a/AlphaStream/Models/Alpha.py
+++ b/AlphaStream/Models/Alpha.py
@@ -54,7 +54,7 @@ class Alpha(object):
 
         self.LiveTradingInsights = json.get('live-trading-insights', None)
 
-        self.OutOfSampleInsights = json.get('out-sample-insights', None)
+        self.OutOfSampleInsights = json.get('out-of-sample-insights', None)
 
         self.Tags = json.get('tags', [])
 

--- a/QuantConnect.AlphaStream/Models/Alpha.cs
+++ b/QuantConnect.AlphaStream/Models/Alpha.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.AlphaStream.Models
         /// <summary>
         /// Number of out-of-sample Insights
         /// </summary>
-        [JsonProperty("out-sample-insights")]
+        [JsonProperty("out-of-sample-insights")]
         public int? OutOfSampleInsights { get; set; }
     }
 }


### PR DESCRIPTION
Alphas now have an OutOfSampleInsight property, which covers the Insights that are generated by the backtest reconciliation (the backtest run over the live-trading period).

Added LiveInsights and InSampleInsights to the C# Alpha class as well.