### PR TITLE
Update to Error Handling

### DIFF
--- a/QuantConnect.AlphaStreamsRunnerAlgorithm/Python/AlphaStreamsRunnerAlgorithm.py
+++ b/QuantConnect.AlphaStreamsRunnerAlgorithm/Python/AlphaStreamsRunnerAlgorithm.py
@@ -95,8 +95,8 @@ class AlphaStreamsRunnerAlgorithm(QCAlgorithm):
                     self.client.Unsubscribe(i)
                     self.Log(f'Unsubscribed from {i}')
                 except:
-                    error = sys.exc_info()[1].args[0]
-                    self.Log(f'Could not unsubscribe from {i} on exiting algorithm: {error[48:]}')
+                    unsubscribeError = sys.exc_info()[1].args[0]
+                    self.Log(f'Could not unsubscribe from {i} on exiting algorithm: {unsubscribeError[48:]}')
 
     def OnOrderEvent(self, orderEvent):
         order = self.Transactions.GetOrderById(orderEvent.OrderId)


### PR DESCRIPTION
Changes will more elegantly handle Subscribe/Unsubscribe errors to avoid unintentional exceptions. The change in AlphaStreamsSocket will now throw an exception such as the below before exiting the algorithm

`20200220 10:22:47.359 ERROR:: Engine.Run(): During the algorithm initialization, the following exception has occurred: Python.Runtime.PythonException: Exception : This token is not authorized to license alphas beyond $0 per month`

or log the following exception before continuing (non-breaking exception)

`20200220 10:31:36.743 Trace:: Log: Already subscribed to a40aa4e9e72f3b3a2b1656952`

Changes to AlphaStreamsRunnerAlgorithm will log an error such as below before exiting:
`20200220 10:22:47.436 Trace:: Log: Could not unsubscribe from a40aa4e9e72f3b3a2b1656952 on exiting algorithm: Subscription not found or already cancelled`