### PR TITLE
Rename C# AlphaStreamClient to AlphaStreamEventClient

### DIFF
--- a/QuantConnect.AlphaStream.Demo/Program.cs
+++ b/QuantConnect.AlphaStream.Demo/Program.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.AlphaStream.Demo
             Title("6. Live Insights and Orders Streaming");
             // Credentials for streaming client
             var streamingCredentials = AlphaStreamCredentials.FromConfiguration();
-            var streamingClient = new AlphaStreamClient(streamingCredentials);
+            var streamingClient = new AlphaStreamEventClient(streamingCredentials);
 
             //Configure client to handle received insights
             streamingClient.InsightReceived += (sender, e) =>

--- a/QuantConnect.AlphaStream.Tests/AlphaStreamClientTests.cs
+++ b/QuantConnect.AlphaStream.Tests/AlphaStreamClientTests.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.AlphaStream.Tests
                 VirtualHost
                 );
 
-            var client = new AlphaStreamClient(info);
+            var client = new AlphaStreamEventClient(info);
             client.Connect();
 
             client.InsightReceived += (sender, args) =>

--- a/QuantConnect.AlphaStream/AlphaInsightsStreamClient.cs
+++ b/QuantConnect.AlphaStream/AlphaInsightsStreamClient.cs
@@ -5,8 +5,8 @@ namespace QuantConnect.AlphaStream
     /// <summary>
     /// Client used to stream live alpha insights.
     /// </summary>
-    /// <remarks>Kept for backwards compatibility <see cref="AlphaStreamClient"/></remarks>
-    public class AlphaInsightsStreamClient : AlphaStreamClient, IAlphaInsightsStreamClient
+    /// <remarks>Kept for backwards compatibility <see cref="AlphaStreamEventClient"/></remarks>
+    public class AlphaInsightsStreamClient : AlphaStreamEventClient, IAlphaInsightsStreamClient
     {
         public AlphaInsightsStreamClient(AlphaStreamCredentials credentials) : base(credentials)
         {

--- a/QuantConnect.AlphaStream/AlphaStreamEventClient.cs
+++ b/QuantConnect.AlphaStream/AlphaStreamEventClient.cs
@@ -17,7 +17,7 @@ namespace QuantConnect.AlphaStream
     /// <summary>
     /// Client used to stream live alpha insights, orders and order events.
     /// </summary>
-    public class AlphaStreamClient : IAlphaStreamClient
+    public class AlphaStreamEventClient : IAlphaStreamClient
     {
         private IModel channel;
         private IConnection connection;
@@ -40,10 +40,10 @@ namespace QuantConnect.AlphaStream
         public event EventHandler<OrderReceivedEventArgs> OrderReceived;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AlphaStreamClient"/> class
+        /// Initializes a new instance of the <see cref="AlphaStreamEventClient"/> class
         /// </summary>
         /// <param name="credentials">The exchange information where the alphas data is disseminated from</param>
-        public AlphaStreamClient(AlphaStreamCredentials credentials)
+        public AlphaStreamEventClient(AlphaStreamCredentials credentials)
         {
             this.credentials = credentials;
             consumersByAlphaId = new Dictionary<string, EventingBasicConsumer>();

--- a/QuantConnect.AlphaStream/QuantConnect.AlphaStream.csproj
+++ b/QuantConnect.AlphaStream/QuantConnect.AlphaStream.csproj
@@ -60,7 +60,7 @@
     <Compile Include="AlphaCredentials.cs" />
     <Compile Include="AlphaInsightsStreamClient.cs" />
     <Compile Include="AlphaInsightsStreamCredentials.cs" />
-    <Compile Include="AlphaStreamClient.cs" />
+    <Compile Include="AlphaStreamEventClient.cs" />
     <Compile Include="AlphaStreamCredentials.cs" />
     <Compile Include="AlphaStreamRestClient.cs" />
     <Compile Include="IAlphaInsightsStreamClient.cs" />


### PR DESCRIPTION
- Rename C# `AlphaStreamClient` to `AlphaStreamEventClient` because Python implementation already had an `AlphaStreamClient` which is actually the rest client