### PR TITLE
Fixes Subscribe Method Missing Argument

### DIFF
--- a/AlphaStream/AlphaStreamRestClient.py
+++ b/AlphaStream/AlphaStreamRestClient.py
@@ -167,9 +167,9 @@ class AlphaStreamRestClient(object):
 
         return authors
 
-    def Subscribe(self, alphaId):
+    def Subscribe(self, alphaId, exclusive=False):
         """ Subscribe to an alpha """
-        request = SubscribeRequest(alphaId)
+        request = SubscribeRequest(alphaId, exclusive)
         result = self.Execute(request)
         return result['success']
 


### PR DESCRIPTION
Adds missing boolean argument to subscribe to an Alpha Stream in exclusive mode.

Note: it's not possible to upgrade/downgrade a subscription. At the moment we need to unsubscribe a shared AS, and then subscribe as exclusive.