### PR TITLE
Change GetAlphaEquityCurve Method Return Type to Pandas DataFrame

### DIFF
--- a/QuantConnect.AlphaStream.Demo/Program.cs
+++ b/QuantConnect.AlphaStream.Demo/Program.cs
@@ -105,7 +105,7 @@ namespace QuantConnect.AlphaStream.Demo
             // 6. Get Equity Curve
             Title("6. Get Equity Curve");
             Log($"6. /alpha/alpha-id/equity: Pulling equity curve data for specific author: '{alphaId}'");
-            var equityCurve = client.GetAlphaEquityCurve(alphaId);
+            var equityCurve = client.GetAlphaEquityCurveCSharp(alphaId);
             foreach (var dataPoint in equityCurve)
             {
                 Log(dataPoint.ToString());

--- a/QuantConnect.AlphaStream.Tests/AlphaStreamRestClientTests.cs
+++ b/QuantConnect.AlphaStream.Tests/AlphaStreamRestClientTests.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.AlphaStream.Tests
         [Test]
         public async Task GetAlphaEquityCurve()
         {
-            var response = _client.GetAlphaEquityCurve("c98a822257cf2087e37fddff9");
+            var response = _client.GetAlphaEquityCurveCSharp("c98a822257cf2087e37fddff9");
             Assert.IsNotNull(response);
             Assert.IsNotEmpty(response);
         }

--- a/QuantConnect.AlphaStream/AlphaStreamRestClient.cs
+++ b/QuantConnect.AlphaStream/AlphaStreamRestClient.cs
@@ -12,6 +12,7 @@ using QuantConnect.AlphaStream.Models;
 using QuantConnect.AlphaStream.Requests;
 using RestSharp;
 using RestSharp.Authenticators;
+using Python.Runtime;
 
 namespace QuantConnect.AlphaStream
 {
@@ -205,6 +206,30 @@ namespace QuantConnect.AlphaStream
                     Equity = Convert.ToDouble(item[1]),
                     Sample = item[2].ToString()
                 }).ToList();
+        }
+
+        /// <summary>
+        /// Get an equity curve for an alpha in pandas DataFrame format.
+        /// </summary>
+        /// <param name="alphaId">Alpha Id for strategy we're downloading.</param>
+        /// <returns>Equity curve list of points in a DataFrame</returns>
+        public PyObject GetAlphaEquityCurveDataFrame(string alphaId)
+        {
+            var equityCurve = GetAlphaEquityCurve(alphaId);
+            using (Py.GIL())
+            {
+                dynamic pandas = Py.Import("pandas");
+
+                var index = equityCurve.Select(x => x.Time).ToList();
+                var equity = equityCurve.Select(x => x.Equity);
+                var sample = equityCurve.Select(x => x.Sample);
+                
+                var pyDict = new PyDict();
+                pyDict.SetItem("equity", pandas.Series(equity, index));
+                pyDict.SetItem("sample", pandas.Series(sample, index));
+
+                return pandas.DataFrame(pyDict);
+            }
         }
 
         /// <summary>

--- a/QuantConnect.AlphaStream/AlphaStreamRestClient.cs
+++ b/QuantConnect.AlphaStream/AlphaStreamRestClient.cs
@@ -193,10 +193,14 @@ namespace QuantConnect.AlphaStream
         /// Get an equity curve for an alpha.
         /// </summary>
         /// <param name="alphaId">Alpha Id for strategy we're downloading.</param>
+        /// <param name="dateFormat">Preferred date format</param>
+        /// <param name="format">Preferred format of returned equity curve</param>
         /// <returns>Equity curve list of points</returns>
-        public List<EquityCurve> GetAlphaEquityCurve(GetAlphaEquityCurveRequest request)
+        public List<EquityCurve> GetAlphaEquityCurveCSharp(string alphaId, string dateFormat = "date", string format = "json")
         {
+            var request = new GetAlphaEquityCurveRequest { Id = alphaId, DateFormat = dateFormat, Format = format };
             var result = Execute(request).Result;
+
             return result.Select(
                 item => new EquityCurve
                 {
@@ -213,41 +217,22 @@ namespace QuantConnect.AlphaStream
         /// <param name="dateFormat">Preferred date format</param>
         /// <param name="format">Preferred format of returned equity curve</param>
         /// <returns>Equity curve list of points</returns>
-        public List<EquityCurve> GetAlphaEquityCurve(string alphaId, string dateFormat = "date", string format = "json")
+        public PyObject GetAlphaEquityCurve(string alphaId, string dateFormat = "date", string format = "json")
         {
-            return GetAlphaEquityCurve(new GetAlphaEquityCurveRequest(alphaId, dateFormat, format));
-        }
+            var equityCurve = GetAlphaEquityCurveCSharp(alphaId, dateFormat, format);
 
-        /// <summary>
-        /// Get an equity curve for an alpha.
-        /// </summary>
-        /// <param name="alphaId">Alpha Id for strategy we're downloading.</param>
-        /// <returns>Equity curve list of points</returns>
-        public PyObject GetAlphaEquityCurve(PyObject pyRequest)
-        {
             using (Py.GIL())
             {
                 dynamic pandas = Py.Import("pandas");
-                GetAlphaEquityCurveRequest request;
-                if (PyString.IsStringType(pyRequest))
-                {
-                    request = new GetAlphaEquityCurveRequest(pyRequest.ToString());
-                }
-                else
-                {
-                    request = pyRequest.SafeAsManagedObject() as GetAlphaEquityCurveRequest;
-                    if (request == null)
-                    {
-                        return pandas.DataFrame();
-                    }
-                }
-                var equityCurve = GetAlphaEquityCurve(request);
+
                 var index = equityCurve.Select(x => x.Time).ToList();
                 var equity = equityCurve.Select(x => x.Equity);
                 var sample = equityCurve.Select(x => x.Sample);
+
                 var pyDict = new PyDict();
                 pyDict.SetItem("equity", pandas.Series(equity, index));
                 pyDict.SetItem("sample", pandas.Series(sample, index));
+
                 return pandas.DataFrame(pyDict);
             }
         }

--- a/QuantConnect.AlphaStream/Requests/GetAlphaEquityCurveRequest.cs
+++ b/QuantConnect.AlphaStream/Requests/GetAlphaEquityCurveRequest.cs
@@ -31,6 +31,27 @@ namespace QuantConnect.AlphaStream.Requests
         public string Format { get; set; } = "json";
 
         /// <summary>
+        /// Create a new instance of GetAlphaEquityCurveRequest.
+        /// </summary>
+        public GetAlphaEquityCurveRequest()
+        {
+
+        }
+
+        /// <summary>
+        /// Create a new instance of GetAlphaEquityCurveRequest.
+        /// </summary>
+        /// <param name="id">Unique id hash of an Alpha published to the marketplace.</param>
+        /// <param name="dateFormat">Preferred date format</param>
+        /// <param name="format">Preferred format of returned equity curve</param>
+        public GetAlphaEquityCurveRequest(string id, string dateFormat = "date", string format = "json")
+        {
+            Id = id;
+            DateFormat = dateFormat;
+            Format = format;
+        }
+
+        /// <summary>
         /// Returns a string that represents the GetAlphaEquityCurveRequest object
         /// </summary>
         /// <returns>A string that represents the GetAlphaEquityCurveRequest object</returns>

--- a/QuantConnect.AlphaStream/Requests/GetAlphaEquityCurveRequest.cs
+++ b/QuantConnect.AlphaStream/Requests/GetAlphaEquityCurveRequest.cs
@@ -31,27 +31,6 @@ namespace QuantConnect.AlphaStream.Requests
         public string Format { get; set; } = "json";
 
         /// <summary>
-        /// Create a new instance of GetAlphaEquityCurveRequest.
-        /// </summary>
-        public GetAlphaEquityCurveRequest()
-        {
-
-        }
-
-        /// <summary>
-        /// Create a new instance of GetAlphaEquityCurveRequest.
-        /// </summary>
-        /// <param name="id">Unique id hash of an Alpha published to the marketplace.</param>
-        /// <param name="dateFormat">Preferred date format</param>
-        /// <param name="format">Preferred format of returned equity curve</param>
-        public GetAlphaEquityCurveRequest(string id, string dateFormat = "date", string format = "json")
-        {
-            Id = id;
-            DateFormat = dateFormat;
-            Format = format;
-        }
-
-        /// <summary>
         /// Returns a string that represents the GetAlphaEquityCurveRequest object
         /// </summary>
         /// <returns>A string that represents the GetAlphaEquityCurveRequest object</returns>


### PR DESCRIPTION
Rename the former method to `GetAlphaEquityCurveCSharp` to keep the option.
Closes #75 