### PR TITLE
Adds Missing Column in GetAlphaEquityCurve Python Version

### DIFF
--- a/AlphaStream/AlphaStreamRestClient.py
+++ b/AlphaStream/AlphaStreamRestClient.py
@@ -104,7 +104,7 @@ class AlphaStreamRestClient(object):
                 i[0] = datetime.utcfromtimestamp(i[0])
             else:
                 i[0] = datetime.strptime(i[0], "%d/%m/%Y %H:%M:%S")
-        return pd.DataFrame.from_records(result, index=['time'], columns=['time', 'equity', 'sample'])
+        return pd.DataFrame.from_records(result, index=['time'], columns=['time', 'equity', 'sample', 'deployment'])
 
 
     def GetAlphaList(self):


### PR DESCRIPTION
The API returns four columns: 'time', 'equity', 'sample', 'deployment', and `pandas.from_records` will parse all of them. The C# version discards the extra information ('deployment'). However, it should be added too.