### PR TITLE
Adds Unified Payload to GetAlphaEquityCurveRequest

### DIFF
--- a/QuantConnect.AlphaStream.Tests/AlphaStreamRestClientTests.cs
+++ b/QuantConnect.AlphaStream.Tests/AlphaStreamRestClientTests.cs
@@ -174,12 +174,20 @@ namespace QuantConnect.AlphaStream.Tests
             Assert.AreEqual(first.StackTrace.Substring(0, 10), "System.Exc");
         }
 
-        [Test]
-        public async Task GetAlphaEquityCurve()
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task GetAlphaEquityCurve(bool unified)
         {
-            var response = _client.GetAlphaEquityCurveCSharp("c98a822257cf2087e37fddff9");
+            var response = _client.GetAlphaEquityCurveCSharp("c98a822257cf2087e37fddff9", unified: unified);
             Assert.IsNotNull(response);
             Assert.IsNotEmpty(response);
+            if (unified) return;
+
+            var sampleGroupDictionary = response.GroupBy(x => x.Sample)
+                .ToDictionary(k => k.Key, v => v.ToList());
+
+            Assert.IsTrue(sampleGroupDictionary.TryGetValue("in sample", out var inSample));
+            Assert.Greater(inSample.Count, 0);
         }
 
         [Test]

--- a/QuantConnect.AlphaStream/AlphaStreamRestClient.cs
+++ b/QuantConnect.AlphaStream/AlphaStreamRestClient.cs
@@ -195,10 +195,11 @@ namespace QuantConnect.AlphaStream
         /// <param name="alphaId">Alpha Id for strategy we're downloading.</param>
         /// <param name="dateFormat">Preferred date format</param>
         /// <param name="format">Preferred format of returned equity curve</param>
+        /// <param name="unified">Unified equity curve. False to get in sample and out of sample data</param>
         /// <returns>Equity curve list of points</returns>
-        public List<EquityCurve> GetAlphaEquityCurveCSharp(string alphaId, string dateFormat = "date", string format = "json")
+        public List<EquityCurve> GetAlphaEquityCurveCSharp(string alphaId, string dateFormat = "date", string format = "json", bool unified = true)
         {
-            var request = new GetAlphaEquityCurveRequest { Id = alphaId, DateFormat = dateFormat, Format = format };
+            var request = new GetAlphaEquityCurveRequest { Id = alphaId, DateFormat = dateFormat, Format = format, Unified = unified };
             var result = Execute(request).Result;
 
             return result.Select(
@@ -216,10 +217,11 @@ namespace QuantConnect.AlphaStream
         /// <param name="alphaId">Alpha Id for strategy we're downloading.</param>
         /// <param name="dateFormat">Preferred date format</param>
         /// <param name="format">Preferred format of returned equity curve</param>
+        /// <param name="unified">Unified equity curve. False to get in sample and out of sample data</param>
         /// <returns>Equity curve list of points</returns>
-        public PyObject GetAlphaEquityCurve(string alphaId, string dateFormat = "date", string format = "json")
+        public PyObject GetAlphaEquityCurve(string alphaId, string dateFormat = "date", string format = "json", bool unified = true)
         {
-            var equityCurve = GetAlphaEquityCurveCSharp(alphaId, dateFormat, format);
+            var equityCurve = GetAlphaEquityCurveCSharp(alphaId, dateFormat, format, unified);
 
             using (Py.GIL())
             {

--- a/QuantConnect.AlphaStream/Requests/GetAlphaEquityCurveRequest.cs
+++ b/QuantConnect.AlphaStream/Requests/GetAlphaEquityCurveRequest.cs
@@ -31,6 +31,14 @@ namespace QuantConnect.AlphaStream.Requests
         public string Format { get; set; } = "json";
 
         /// <summary>
+        /// Preferred content of returned equity curve.
+        /// If False, returns data of one single Alpha with the following sampling: in sample, out of sample, and live trading
+        /// If True, returns unified data of all versions of this Alpha with the live trading sampling only
+        /// </summary>
+        [QueryParameter("unified")]
+        public bool Unified { get; set; } = true;
+
+        /// <summary>
         /// Returns a string that represents the GetAlphaEquityCurveRequest object
         /// </summary>
         /// <returns>A string that represents the GetAlphaEquityCurveRequest object</returns>


### PR DESCRIPTION
`unified = 'false'` includes `in sample` and `out of sample` data.