### PR TITLE
Adds Alpha Id to the EquityCurve Object

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Checkout Lean
+      - name: Checkout Lean Same Branch
+        id: lean-same-branch
         uses: actions/checkout@v2
+        continue-on-error: true
         with:
           ref: ${{ github.ref }}
           repository: QuantConnect/Lean
           path: Lean
+
+      - name: Checkout Lean Master
+        if: steps.lean-same-branch.outcome != 'success'
+        uses: actions/checkout@v2
+        with:
+          repository: QuantConnect/Lean
+          path: Lean
+
       - name: Move Lean
         run: mv Lean ../Lean
 

--- a/QuantConnect.AlphaStream.Tests/AlphaStreamRestClientTests.cs
+++ b/QuantConnect.AlphaStream.Tests/AlphaStreamRestClientTests.cs
@@ -178,10 +178,20 @@ namespace QuantConnect.AlphaStream.Tests
         [TestCase(true)]
         public async Task GetAlphaEquityCurve(bool unified)
         {
-            var response = _client.GetAlphaEquityCurveCSharp("c98a822257cf2087e37fddff9", unified: unified);
+            var response = _client.GetAlphaEquityCurveCSharp("f50519a3d2b2598960bcdb59d", unified: unified);
             Assert.IsNotNull(response);
             Assert.IsNotEmpty(response);
-            if (unified) return;
+
+            var idCount = response.GroupBy(x => x.Id).Count();
+
+            // If we request the unified equity curve, it will include data for more than one version
+            if (unified)
+            {
+                Assert.Greater(idCount, 1);
+                return;
+            }
+
+            Assert.AreEqual(1, idCount);
 
             var sampleGroupDictionary = response.GroupBy(x => x.Sample)
                 .ToDictionary(k => k.Key, v => v.ToList());

--- a/QuantConnect.AlphaStream/AlphaStreamRestClient.cs
+++ b/QuantConnect.AlphaStream/AlphaStreamRestClient.cs
@@ -204,11 +204,12 @@ namespace QuantConnect.AlphaStream
 
             return result.Select(
                 item => new EquityCurve
-                {
-                    Time = DateTime.ParseExact(item[0].ToString(), "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture),
-                    Equity = Convert.ToDouble(item[1]),
-                    Sample = item[2].ToString()
-                }).ToList();
+                (
+                    DateTime.ParseExact(item[0].ToString(), "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture),
+                    Convert.ToDouble(item[1]),
+                    item[2].ToString(),
+                    item.Length > 3 ? item[3].ToString() : ""
+                )).ToList();
         }
 
         /// <summary>
@@ -230,10 +231,12 @@ namespace QuantConnect.AlphaStream
                 var index = equityCurve.Select(x => x.Time).ToList();
                 var equity = equityCurve.Select(x => x.Equity);
                 var sample = equityCurve.Select(x => x.Sample);
+                var id = equityCurve.Select(x => x.Id);
 
                 var pyDict = new PyDict();
                 pyDict.SetItem("equity", pandas.Series(equity, index));
                 pyDict.SetItem("sample", pandas.Series(sample, index));
+                pyDict.SetItem("id", pandas.Series(id, index));
 
                 return pandas.DataFrame(pyDict);
             }

--- a/QuantConnect.AlphaStream/Models/EquityCurve.cs
+++ b/QuantConnect.AlphaStream/Models/EquityCurve.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using Newtonsoft.Json;
-using QuantConnect.Util;
 
 namespace QuantConnect.AlphaStream.Models
 {
@@ -9,28 +7,42 @@ namespace QuantConnect.AlphaStream.Models
         /// <summary>
         /// Timestamp of equity curve point
         /// </summary>
-        [JsonProperty("time"), JsonConverter(typeof(DoubleUnixSecondsDateTimeJsonConverter))]
-        public DateTime Time { get; set; }
+        public DateTime Time { get; }
+
+        /// <summary>
+        /// Alpha Id. Unified equity curve has data of more than one version of an Alpha.
+        /// </summary>
+        public string Id { get; }
 
         /// <summary>
         /// Dollar value of the equity
         /// </summary>
-        [JsonProperty("equity")]
-        public double Equity { get; set; }
+        public double Equity { get; }
 
         /// <summary>
         /// Sample of equity point (in-sample or live-trading)
         /// </summary>
-        [JsonProperty("sample")]
-        public string Sample { get; set; }
+        public string Sample { get; }
+
+        /// <summary>
+        /// Creates a new instance of EquityCurve
+        /// </summary>
+        /// <param name="time">Timestamp of equity curve point</param>
+        /// <param name="equity">Dollar value of the equity</param>
+        /// <param name="sample">Sample of equity point (in-sample or live-trading)</param>
+        /// <param name="id">Alpha Id. Unified equity curve has data of more than one version of an Alpha.</param>
+        public EquityCurve(DateTime time, double equity, string sample, string id)
+        {
+            Time = time;
+            Equity = equity;
+            Sample = sample;
+            Id = id;
+        }
 
         /// <summary>
         /// Returns a string that represents the EquityCurve object
         /// </summary>
         /// <returns>A string that represents the EquityCurve object</returns>
-        public override string ToString()
-        {
-            return $"{Time},{Equity},{Sample}";
-        }
+        public override string ToString() => $"{Time},{Equity},{Sample},{Id}";
     }
 }


### PR DESCRIPTION
When we request unified equity curve, we receive data from more than one version of the Alpha, and we need to have their identification for data analysis.